### PR TITLE
Point release.

### DIFF
--- a/.github/skills/version-bump/SKILL.md
+++ b/.github/skills/version-bump/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: version-bump
+description: "Bump the bocpy version across all required files. Use when: incrementing the version, releasing a new version, updating version strings, preparing a release, changing the version number, or adding a changelog entry."
+---
+
+# Version Bump
+
+When asked to bump the version to a specific version (e.g. `0.3.0`), propose
+edits to **all** of the following files. Do not skip any.
+
+## Files to Update
+
+### 1. `pyproject.toml`
+
+Update the `version` field under `[project]`:
+
+```toml
+[project]
+name = "bocpy"
+version = "<NEW_VERSION>"
+```
+
+### 2. `sphinx/source/conf.py`
+
+Update the `release` variable:
+
+```python
+release = '<NEW_VERSION>'
+```
+
+### 3. `CITATION.cff`
+
+Update both `version` and `date-released`:
+
+```yaml
+version: <NEW_VERSION>
+date-released: <TODAY YYYY-MM-DD>
+```
+
+### 4. `CHANGELOG.md`
+
+Prepend a new entry **at the top** of the file with today's date, the new
+version, and a placeholder for the user to fill in:
+
+```markdown
+## <TODAY YYYY-MM-DD> - Version <NEW_VERSION>
+TODO: Add release notes.
+
+```
+
+## Procedure
+
+1. Read the current version from `pyproject.toml` to confirm the old value.
+2. Propose all four edits as a single changeset.
+3. Use today's date (from context) for the CHANGELOG and CITATION entries.
+4. Do **not** commit — the user handles git operations.

--- a/.github/workflows/pr_gate.yml
+++ b/.github/workflows/pr_gate.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Use Python 3.14
         uses: actions/setup-python@v5
@@ -31,7 +31,7 @@ jobs:
           - check: src/bocpy
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run clang-format style check
         uses: jidicula/clang-format-action@v4.8.0
@@ -47,10 +47,10 @@ jobs:
         python_version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Use Python ${{matrix.python_version}}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{matrix.python_version}}
 
@@ -71,10 +71,10 @@ jobs:
         python_version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Use Python ${{matrix.python_version}}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{matrix.python_version}}
 
@@ -95,10 +95,10 @@ jobs:
         python_version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Use Python ${{matrix.python_version}}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{matrix.python_version}}
 
@@ -119,10 +119,10 @@ jobs:
         python_version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Use Python ${{matrix.python_version}}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{matrix.python_version}}
 
@@ -135,3 +135,53 @@ jobs:
 
       - name: Python test
         run: pytest -vv
+
+  asan:
+    runs-on: ubuntu-latest
+    env:
+      CPYTHON_VERSION: v3.14.2
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang llvm build-essential pkg-config \
+            libbz2-dev libffi-dev libgdbm-dev libgdbm-compat-dev liblzma-dev \
+            libncurses5-dev libreadline6-dev libsqlite3-dev libssl-dev \
+            lzma lzma-dev tk-dev uuid-dev zlib1g-dev libzstd-dev
+
+      - name: Download CPython ${{ env.CPYTHON_VERSION }}
+        run: |
+          git clone --depth 1 --branch ${{ env.CPYTHON_VERSION }} \
+            https://github.com/python/cpython.git "$RUNNER_TEMP/cpython-src"
+
+      - name: Build CPython with ASAN and UBSAN
+        working-directory: ${{ runner.temp }}/cpython-src
+        run: |
+          CC=clang ./configure \
+            --with-address-sanitizer \
+            --without-pymalloc \
+            --with-undefined-behavior-sanitizer \
+            --without-system-libmpdec
+          make -j"$(nproc)"
+
+      - name: Create virtual environment
+        run: |
+          "$RUNNER_TEMP/cpython-src/python" -m venv "$RUNNER_TEMP/asan-venv"
+
+      - name: Build bocpy
+        run: |
+          source "$RUNNER_TEMP/asan-venv/bin/activate"
+          python -m pip install --upgrade pip
+          CC="clang -fsanitize=address,undefined -fno-sanitize=vptr" \
+            pip install -e .[test] --verbose
+
+      - name: Run tests
+        env:
+          ASAN_OPTIONS: detect_leaks=0:halt_on_error=1
+          UBSAN_OPTIONS: halt_on_error=1:print_stacktrace=1
+        run: |
+          source "$RUNNER_TEMP/asan-venv/bin/activate"
+          pytest -vv

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+## 2026-03-17 - Version 0.2.2
+Point release.
+
+**Improvements**
+- Added an ASAN/UBSAN CI job that builds CPython 3.14.2 from source with
+  AddressSanitizer and UndefinedBehaviorSanitizer, then runs the full test suite
+  against instrumented builds of bocpy.
+- Updated GitHub Actions to latest versions (`actions/checkout@v6`,
+  `actions/setup-python@v5`).
+- Added a Copilot skill for version bumping.
+
+**Bug Fixes**
+- Fixed a missing `Py_DECREF` on a temporary `PyObject` in the xidata recycling
+  path, plugging a reference leak.
+- Fixed `PyMem_RawFree` freeing the wrong pointer (`xidata->obj` instead of
+  `xidata`) in the recycling queue cleanup.
+
 ## 2026-03-11 - Version 0.2.1
 Point release.
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,6 +5,6 @@ authors:
   given-names: "Matthew Alastair"
   orcid: "https://orcid.org/0000-0002-1019-8036"
 title: "bocpy"
-version: 2.0.4
-date-released: 2026-02-11
+version: 0.2.2
+date-released: 2026-03-17
 url: "https://github.com/microsoft/bocpy"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bocpy"
-version = "0.2.1"
+version = "0.2.2"
 authors = [
     {name = "bocpy Team", email="bocpy@microsoft.com"}
 ]

--- a/sphinx/source/conf.py
+++ b/sphinx/source/conf.py
@@ -14,7 +14,7 @@ import textwrap
 project = 'bocpy'
 copyright = '2026, Microsoft'
 author = 'Microsoft'
-release = '0.2.1'
+release = '0.2.2'
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/src/bocpy/_core.c
+++ b/src/bocpy/_core.c
@@ -969,6 +969,8 @@ static void BOCRecycleQueue_recycle(BOCRecycleQueue *queue, XIDATA_T *xidata) {
             queue->index);
   }
 
+  Py_DECREF(xidata_ptr);
+
   // manual clear
   if (xidata->data != NULL) {
     if (xidata->free != NULL) {
@@ -978,7 +980,7 @@ static void BOCRecycleQueue_recycle(BOCRecycleQueue *queue, XIDATA_T *xidata) {
   }
 
   Py_CLEAR(xidata->obj);
-  PyMem_RawFree(xidata->obj);
+  PyMem_RawFree(xidata);
 }
 
 /// @brief Enqeues an xidata on the recycling queue.


### PR DESCRIPTION
**Improvements**
- Added an ASAN/UBSAN CI job that builds CPython 3.14.2 from source with AddressSanitizer and UndefinedBehaviorSanitizer, then runs the full test suite against instrumented builds of bocpy.
- Updated GitHub Actions to latest versions (`actions/checkout@v6`, `actions/setup-python@v5`).
- Added a Copilot skill for version bumping.

**Bug Fixes**
- Fixed a missing `Py_DECREF` on a temporary `PyObject` in the xidata recycling path, plugging a reference leak.
- Fixed `PyMem_RawFree` freeing the wrong pointer (`xidata->obj` instead of `xidata`) in the recycling queue cleanup.