### PR TITLE
Spin-then-park receive, free-threaded Python compatibility.

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -134,20 +134,12 @@ Before modifying any code:
 
 ### Review every non-trivial change
 
-After implementing a change, follow this review process:
+After implementing a change, run the **review-loop** skill to get an independent
+review. This may be skipped for trivial changesets, but you do not decide what
+qualifies as trivial — ask for approval first.
 
-1. **Spawn a subagent** with a fresh context to review the changed code.
-2. **Make a plan** to address the reviewer's comments. Present that plan for
-   approval before acting on it.
-3. **Repeat** — go back to step 1 until the reviewer has no further comments.
-
-This process may be skipped for trivial changesets, but you do not decide what
-qualifies as trivial. If you believe a change is a candidate for skipping
-review, ask for approval first.
-
-The review process removes me as gatekeeper but I am still your collaborator.
-If you are unsure how to address a reviewer's comment, ask me rather than
-guessing.
+I am still your collaborator. If you are unsure how to address a reviewer's
+comment, ask me rather than guessing.
 
 ### Fix root causes, not symptoms
 

--- a/.github/skills/branch-review/SKILL.md
+++ b/.github/skills/branch-review/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: branch-review
+description: "Multi-perspective code review for a branch before merging. Use when: reviewing a branch, preparing a PR, pre-merge review, auditing a feature branch, or when /branch-review is invoked. Spawns four reviewer subagents with competing priorities (correctness, security, maintainability, adversarial) then synthesizes their findings into a unified review report."
+argument-hint: "Branch name or merge target (e.g. 'main' or 'feature/foo -> main')"
+---
+
+# Branch Review
+
+Perform a thorough multi-perspective code review of a branch before it is
+merged. Four independent reviewers examine the diff from competing viewpoints,
+and their findings are synthesized into one actionable report.
+
+## When to Use
+
+- A feature branch is ready to merge and needs review
+- Preparing a pull request
+- Final quality gate before integration
+
+## Severity Levels
+
+Findings use the same severity scale as the **review-loop** skill:
+
+| Severity | Meaning |
+|----------|---------|
+| **critical** | Correctness bug, security vulnerability, or data loss risk. Must fix. |
+| **high** | Likely bug, race condition, or significant design flaw. Should fix. |
+| **medium** | Code smell, unclear logic, missing edge case, or maintainability concern. Recommended fix. |
+| **low** | Style nit, naming suggestion, minor improvement. Fix at discretion. |
+
+## Procedure
+
+### 1. Gather the Diff
+
+Determine the branch and its merge target (default: `main`). Collect the diff
+using one of these methods, in order of preference:
+
+1. `git diff <merge-target>...<branch> -- . ':!*.lock'` — full diff against
+   the merge base.
+2. `get_changed_files` — if the working tree has uncommitted changes that are
+   part of the review.
+
+Also collect the list of changed files:
+
+```
+git diff --name-only <merge-target>...<branch>
+```
+
+Read the full current content of every changed file so reviewers have both the
+diff and the surrounding context.
+
+### 2. Build the Context Block
+
+Assemble a context block that every reviewer will receive. It must include:
+
+- **Diff** — the full unified diff.
+- **Changed files** — full current content of each modified file.
+- **Related tests** — content of test files that cover the changed code, if
+  identifiable.
+- **Project conventions** — brief summary of relevant conventions from
+  `copilot-instructions.md` (style, commenting, error handling, etc.).
+
+Keep the context block identical across all four reviewers to ensure a fair
+comparison.
+
+### 3. Spawn Four Reviewer Subagents
+
+Launch four subagents **in parallel**. Each receives the context block plus a
+persona directive. Each must return findings in the severity-tagged format
+defined above.
+
+| # | Persona | Directive |
+|---|---------|-----------|
+| 1 | **Correctness** | Focus exclusively on functional correctness. Look for logic errors, off-by-one mistakes, incorrect state transitions, broken invariants, missing error handling at system boundaries, and test gaps. Ignore style. |
+| 2 | **Security** | Focus exclusively on security. Look for injection flaws, buffer overflows, race conditions exploitable by an attacker, unsafe deserialization, credential leaks, missing input validation at trust boundaries, and OWASP Top 10 issues. Ignore style. |
+| 3 | **Maintainability** | Focus on code quality and long-term health. Look for unclear naming, excessive complexity, duplicated logic, missing or misleading comments, poor abstractions, and violations of project conventions (flake8 rules, comment style, etc.). Ignore performance unless it causes a correctness issue. |
+| 4 | **Adversarial** | Assume the code is wrong and try to break it. Construct pathological inputs, race windows, resource exhaustion scenarios, and edge cases. Challenge every assumption. Only clear findings that survive scrutiny. |
+
+Each subagent prompt must include:
+
+- The shared context block
+- The persona directive (from the table above)
+- These instructions:
+
+  > Review the diff and changed files from the perspective described above.
+  > For each issue found, report it in this exact format:
+  >
+  >   **[SEVERITY] Short title**
+  >   - **Location:** file path and line number(s)
+  >   - **Problem:** what is wrong and why it matters
+  >   - **Suggestion:** concrete fix or remediation
+  >
+  >   where SEVERITY is one of: critical, high, medium, low.
+  >
+  > If you find no issues from your perspective, state that explicitly.
+  > Do NOT fabricate issues. Only report genuine problems.
+  > Order findings by severity (critical first).
+
+### 4. Deduplicate and Synthesize
+
+After all four reviewers return:
+
+1. **Merge duplicates.** If multiple reviewers flag the same issue, keep the
+   most detailed version and note which perspectives flagged it (higher
+   confidence).
+2. **Resolve conflicts.** If reviewers disagree (e.g., correctness wants
+   inlining but maintainability wants extraction), note both sides and flag
+   the trade-off for the user.
+3. **Verify critical/high findings.** Before presenting critical or high
+   findings, attempt to verify them — trace the code path, run relevant tests,
+   or construct a minimal reproduction. Mark any finding you cannot verify as
+   **[unverified]**.
+
+### 5. Present the Report
+
+Present a single unified review report to the user:
+
+1. **Summary** — one-paragraph overview: number of findings by severity, overall
+   assessment (e.g., "ready to merge with minor fixes" or "has blocking issues").
+2. **Findings** — listed by severity (critical first). Each finding includes:
+   - The severity tag and title
+   - Location (as a file link with line numbers)
+   - Problem description
+   - Suggested fix
+   - Which reviewer perspectives flagged it
+3. **Trade-offs** — any unresolved disagreements between reviewers, with both
+   sides stated.
+4. **Action prompt** — ask the user which findings to address. Options:
+   - Fix all
+   - Select specific findings by number
+   - Dismiss specific findings
+   - Ask for clarification
+
+### 6. Apply Fixes
+
+For each approved finding:
+
+1. Implement the fix (or the user's alternative if provided).
+2. Confirm each fix briefly as it is applied.
+3. Run relevant tests after each fix to verify no regressions.
+
+If a fix is ambiguous or touches architecture, ask the user for guidance.
+
+### 7. Check Exit or Re-review
+
+After all approved fixes are applied:
+
+> All approved fixes have been applied and tests pass. Should I run another
+> review pass on the updated diff, or is the branch ready to merge?
+
+- If the user wants another pass → go to **step 1** with the updated diff.
+- If the user is satisfied → exit.
+
+## Guidelines
+
+- **Fresh context per pass.** Each review pass spawns new subagents with no
+  memory of prior passes, preventing anchoring bias.
+- **Do not auto-fix without approval.** Always present findings and wait for
+  the user to decide.
+- **Scope to the diff.** Reviewers should focus on changed code. Pre-existing
+  issues in unchanged code are out of scope unless the change makes them worse.
+- **Keep it bounded.** If a re-review returns only low-severity findings,
+  suggest exiting the loop.
+- **Test after fixing.** Run the test suite (or at minimum the relevant subset)
+  after applying fixes to catch regressions early.

--- a/.github/skills/multi-perspective-plan/SKILL.md
+++ b/.github/skills/multi-perspective-plan/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: multi-perspective-plan
+description: "Multi-perspective planning with adversarial review. Use when: planning complex changes, designing architecture, evaluating implementation strategies, drafting implementation plans, or when /plan is invoked. Spawns four subagents with competing priorities (speed, usability, conservatism, adversarial) then synthesizes their outputs into a balanced final plan."
+argument-hint: "Describe the change or feature to plan"
+---
+
+# Multi-Perspective Planning
+
+Generate a robust implementation plan by soliciting four competing viewpoints
+and synthesizing them into a single balanced proposal.
+
+## When to Use
+
+- Planning non-trivial code changes that touch multiple subsystems
+- Evaluating architecture or design trade-offs
+- Any time you want a plan stress-tested before implementation
+
+## Procedure
+
+### 1. Gather Context
+
+Before spawning planners, collect enough context about the target code so each
+subagent can work from the same facts. Read the relevant source files and tests.
+Summarize the current state in a brief context block that will be included in
+every subagent prompt.
+
+### 2. Spawn Four Planner Subagents
+
+Launch four subagents **in parallel**. Each receives the same context block plus
+a persona directive. Each must return a concrete, step-by-step implementation
+plan (not just commentary).
+
+| # | Persona | Directive |
+|---|---------|-----------|
+| 1 | **Speed** | Obsessed with performance. Minimize latency and overhead at all costs. Inline aggressively, avoid abstractions, prefer lock-free and wait-free primitives. Tolerate complexity if it buys speed. |
+| 2 | **Usability** | Prioritize clean, readable, maintainable code. Favor clear abstractions, good naming, and small functions. Accept modest performance cost for clarity. |
+| 3 | **Conservative** | Minimize the changeset. Touch as few lines as possible. Prefer surgical edits over refactors. Reuse existing patterns. Resist new dependencies or abstractions. |
+| 4 | **Adversarial** | Assume the plan is wrong. Actively try to break the design. Look for race conditions, deadlocks, ABA problems, platform bugs, edge cases, and failure modes. Start from skepticism and only endorse what survives scrutiny. |
+
+Each subagent prompt must include:
+
+- The shared context block
+- The persona directive (from the table above)
+- A request for a **numbered step-by-step plan** with rationale per step
+- A request for **risks and mitigations** specific to their perspective
+
+### 3. Review the Four Plans
+
+After all four subagents return, review their outputs yourself. Write a brief
+analysis noting:
+
+- Points of agreement (high-confidence decisions)
+- Points of disagreement (trade-offs to resolve)
+- Risks raised by the adversarial planner that others missed
+- Any gaps none of the planners addressed
+
+### 4. Synthesize
+
+Send all four plans **plus your analysis** to a fifth subagent with the
+directive:
+
+> You are a senior engineer synthesizing four competing implementation plans
+> into one final plan. Preserve the strongest ideas from each perspective.
+> Where planners disagree, make an explicit trade-off decision and justify it.
+> The final plan must be a numbered step-by-step implementation sequence with
+> clear rationale. Flag any unresolved risks.
+
+### 5. Present
+
+Present the synthesized plan to the user for approval. Clearly attribute which
+ideas came from which perspective where relevant.

--- a/.github/skills/review-loop/SKILL.md
+++ b/.github/skills/review-loop/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: review-loop
+description: "Iterative review loop with subagent reviewer. Use when: reviewing code changes, reviewing plans, auditing implementations, validating fixes, running code review, performing quality checks, or when /review is invoked. Spawns a fresh subagent to review a user-specified target, reports severity-tagged findings, applies approved fixes, and repeats until the user is satisfied."
+argument-hint: "Describe or reference the target to review (file paths, plan, diff, etc.)"
+---
+
+# Review Loop
+
+Iteratively review a target (code or plan) using a fresh subagent reviewer,
+present findings, apply fixes, and repeat until the user approves.
+
+## When to Use
+
+- After implementing a non-trivial change
+- Validating a plan before execution
+- Auditing code for correctness, style, or security issues
+- Any time you want an independent second opinion on work in progress
+
+## Severity Levels
+
+Findings are tagged with one of four severities:
+
+| Severity | Meaning |
+|----------|---------|
+| **critical** | Correctness bug, security vulnerability, or data loss risk. Must fix. |
+| **high** | Likely bug, race condition, or significant design flaw. Should fix. |
+| **medium** | Code smell, unclear logic, missing edge case, or maintainability concern. Recommended fix. |
+| **low** | Style nit, naming suggestion, minor improvement. Fix at discretion. |
+
+## Procedure
+
+### 1. Identify the Review Target
+
+Ask the user what to review if not already specified. The target can be:
+
+- One or more source files (by path)
+- A plan (in session memory or conversation)
+- A diff or set of changes
+- A specific function, class, or module
+
+Gather the full content of the target so it can be passed to the reviewer.
+
+### 2. Spawn Reviewer Subagent
+
+Launch a subagent with the following prompt structure:
+
+> You are a code reviewer performing a thorough review of the following target.
+> Your job is to find bugs, design flaws, security issues, and quality problems.
+>
+> **Review target:**
+> {include the full content of the target here}
+>
+> **Additional context:**
+> {include relevant surrounding code, tests, or specifications the reviewer
+> needs to understand the target}
+>
+> **Instructions:**
+> - Review the target for correctness, security, performance, readability, and
+>   adherence to project conventions.
+> - For each issue found, report it in this exact format:
+>
+>   **[SEVERITY] Short title**
+>   - **Location:** file path and line number (or plan step)
+>   - **Problem:** what is wrong and why it matters
+>   - **Suggestion:** concrete fix or remediation
+>
+>   where SEVERITY is one of: critical, high, medium, low.
+>
+> - If you find no issues, state explicitly that the target looks correct.
+> - Do NOT fabricate issues. Only report genuine problems.
+> - Order findings by severity (critical first).
+
+Use the `Explore` subagent for read-only review of code. If the reviewer needs
+to run tests or execute code to verify a finding, note that as an unverified
+finding and let the main agent handle verification.
+
+### 3. Present Findings
+
+After the reviewer returns:
+
+1. List all findings grouped by severity.
+2. For each finding, include the reviewer's suggested remediation.
+3. If the reviewer found no issues, report that explicitly.
+4. Ask the user which findings to address. The user may:
+   - Approve all fixes
+   - Select specific findings to fix
+   - Dismiss findings they disagree with
+   - Ask for clarification on any finding
+
+### 4. Apply Fixes
+
+For each approved finding:
+
+1. Implement the suggested fix (or an alternative if the user provides one).
+2. Briefly confirm each fix as it is applied.
+
+If a fix is non-trivial or ambiguous, ask the user for guidance rather than
+guessing.
+
+### 5. Check Exit Condition
+
+After fixes are applied, ask the user:
+
+> All approved fixes have been applied. Should I run another review pass, or
+> are we done?
+
+- If the user wants another pass → go to **step 2** with the updated target.
+- If the user is satisfied → exit the loop.
+
+## Guidelines
+
+- **Fresh context per pass.** Each reviewer subagent starts with no memory of
+  previous passes. This prevents anchoring bias and ensures new eyes on the
+  updated code.
+- **Do not auto-fix without approval.** Always present findings and wait for
+  the user to decide which to address.
+- **Verify critical findings.** If the reviewer flags a critical or high issue,
+  attempt to verify it (e.g., by running tests or tracing the code) before
+  presenting it to the user. Mark unverified findings as such.
+- **Keep the loop bounded.** If the reviewer returns only low-severity findings
+  on two consecutive passes, suggest exiting the loop.

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -12,20 +12,20 @@ jobs:
         python: [cp310, cp311, cp312, cp313, cp314]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Git config for fetching pull requests
         run: |
           git config --global --add remote.origin.fetch +refs/pull/*/merge:refs/remotes/pull/*
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v3.2.1
+        uses: pypa/cibuildwheel@v3.4.0
         env:
           CIBW_BUILD: ${{ matrix.python }}-win*
         with:
           package-dir: ${{github.workspace}}
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: wheels-${{ matrix.python }}-windows
           path: ./wheelhouse/*.whl
@@ -37,9 +37,9 @@ jobs:
         python: [cp310, cp311, cp312, cp313, cp314]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         id: python
         with:
           python-version: "3.10 - 3.14"
@@ -54,14 +54,14 @@ jobs:
           export PATH=$(python3 -m site --user-base)/bin:$PATH
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v3.2.1
+        uses: pypa/cibuildwheel@v3.4.0
         env:
           CIBW_BUILD: ${{ matrix.python }}-macosx*
           CIBW_ARCHS_MACOS: arm64
         with:
           package-dir: ${{github.workspace}}
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: wheels-${{ matrix.python }}-mac-arm64
           path: ./wheelhouse/*.whl
@@ -73,9 +73,9 @@ jobs:
         python: [cp310, cp311, cp312, cp313, cp314]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         id: python
         with:
           python-version: "3.10 - 3.14"
@@ -90,7 +90,7 @@ jobs:
           export PATH=$(python3 -m site --user-base)/bin:$PATH
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v3.2.1
+        uses: pypa/cibuildwheel@v3.4.0
         env:
           CIBW_BUILD: ${{ matrix.python }}-macosx*
           CIBW_ARCHS_MACOS: x86_64
@@ -98,7 +98,7 @@ jobs:
         with:
           package-dir: ${{github.workspace}}
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: wheels-${{ matrix.python }}-mac-x86_64
           path: ./wheelhouse/*.whl
@@ -110,21 +110,21 @@ jobs:
         python: [cp310, cp311, cp312, cp313, cp314]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Git config for fetching pull requests
         run: |
           git config --global --add remote.origin.fetch +refs/pull/*/merge:refs/remotes/pull/*
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v3.2.1
+        uses: pypa/cibuildwheel@v3.4.0
         env:
           CIBW_BUILD: ${{ matrix.python }}-manylinux*
           CIBW_BEFORE_ALL: yum makecache
         with:
           package-dir: ${{github.workspace}}
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: wheels-${{ matrix.python }}-manylinux
           path: ./wheelhouse/*.whl
@@ -137,20 +137,20 @@ jobs:
         python: [cp310, cp311, cp312, cp313, cp314]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Git config for fetching pull requests
         run: |
           git config --global --add remote.origin.fetch +refs/pull/*/merge:refs/remotes/pull/*
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v3.2.1
+        uses: pypa/cibuildwheel@v3.4.0
         env:
           CIBW_BUILD: ${{ matrix.python }}-musllinux*
         with:
           package-dir: ${{github.workspace}}
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: wheels-${{ matrix.python }}-musllinux
           path: ./wheelhouse/*.whl
@@ -165,13 +165,13 @@ jobs:
       runs-on: ubuntu-latest
       steps:
       - name: Download Wheels
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: wheelhouse
           pattern: wheels-*
           merge-multiple: true
       - run: ls -R wheelhouse
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: wheels
           path: ./wheelhouse/*

--- a/.github/workflows/pr_gate.yml
+++ b/.github/workflows/pr_gate.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Use Python 3.14
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: 3.14
 
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Run clang-format style check
-        uses: jidicula/clang-format-action@v4.8.0
+        uses: jidicula/clang-format-action@v4.18.0
         with:
           clang-format-version: '18'
           check-path: ${{matrix.path['check']}}
@@ -50,7 +50,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Use Python ${{matrix.python_version}}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{matrix.python_version}}
 
@@ -74,7 +74,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Use Python ${{matrix.python_version}}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{matrix.python_version}}
 
@@ -98,7 +98,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Use Python ${{matrix.python_version}}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{matrix.python_version}}
 
@@ -122,7 +122,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Use Python ${{matrix.python_version}}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{matrix.python_version}}
 
@@ -135,6 +135,40 @@ jobs:
 
       - name: Python test
         run: pytest -vv
+
+  free-threaded:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python_version: ["3.13t", "3.14t"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Use Python ${{matrix.python_version}}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{matrix.python_version}}
+
+      - name: Get dependencies
+        run: |
+          python -m pip install --upgrade pip
+
+      - name: Python build
+        run: pip install -e .[test] --verbose
+
+      - name: Verify GIL is disabled
+        run: python -c "import sys; assert not sys._is_gil_enabled(), 'GIL should be disabled'"
+
+      - name: Verify import does not re-enable GIL
+        run: python -c "import bocpy; import sys; assert not sys._is_gil_enabled(), 'GIL re-enabled on import'"
+
+      - name: Python test
+        uses: nick-fields/retry@v4
+        with:
+          max_attempts: 3
+          timeout_minutes: 10
+          command: pytest -vv
 
   asan:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,69 @@
+## 2026-04-01 - Version 0.3.0
+Spin-then-park receive; free-threaded Python compatibility.
+
+**Improvements**
+
+- Added `CownCapsule.disown()` — abandons a cown's value without
+  serializing it and resets ownership to `NO_OWNER`. Used during worker
+  cleanup to safely discard orphan cowns before the owning interpreter
+  is destroyed, preventing dangling Python object references.
+- Rewrote `receive` to use a two-phase spin-then-park strategy for
+  single-tag untimed receives. Phase 1 spins for `BOC_SPIN_COUNT`
+  iterations; Phase 2 parks the thread on a per-queue condvar, eliminating
+  busy-wait CPU burn. Timed receives and multi-tag receives use
+  spin-then-backoff with exponential sleep (1 µs → 1 ms cap).
+- Added platform-abstracted condvar primitives (`BOCParkMutex` /
+  `BOCParkCond`) with implementations for Windows (SRWLOCK /
+  CONDITION_VARIABLE), macOS (pthreads), and Linux (C11 threads).
+- Each `BOCQueue` now carries a `waiters` counter, `park_mutex`, and
+  `park_cond`. Producers signal parked receivers after enqueue;
+  `drain` and `set_tags` broadcast to wake all parked threads.
+- Replaced the fixed `thrd_sleep` in `send` with a `sched_yield` /
+  `SwitchToThread`, reducing send-side latency.
+- Refactored the monolithic `_core_receive` into `receive_single_tag`
+  and `receive_multi_tag`, each with its own backoff/parking logic.
+- Moved the `BOC_QUEUE_DISABLED` check earlier in `get_queue_for_tag`
+  so callers skip disabled queues instead of returning NULL after
+  tag resolution.
+- Added Windows-compatible `atomic_load_explicit` /
+  `atomic_fetch_add_explicit` / `atomic_fetch_sub_explicit` macros
+  using `InterlockedExchangeAdd64`.
+- Declared `Py_mod_gil = Py_MOD_GIL_NOT_USED` in both `_core` and
+  `_math` C extensions so that importing bocpy on a free-threaded
+  Python build (3.13t+) does not re-enable the GIL.
+- Replaced `PyDict_GetItem` (borrowed reference) with
+  `PyDict_GetItemRef` (strong reference) in `BOCRecycleQueue_recycle`
+  on Python 3.13+, improving forward-compatibility with free-threaded
+  builds.
+
+**Bug Fixes**
+
+- Fixed a deadlock when the same cown is passed multiple times to `@when`
+  (e.g. `@when(c, c)`). Duplicate requests for the same cown caused the
+  MCS-queue-based two-phase locking to spin-wait on itself. Requests are
+  now deduplicated by target cown in `Behavior.__init__`, with
+  compensating `resolve_one` calls to maintain the behavior count
+  invariant.
+
+**Tests**
+
+- `TestLostWakeStress`: single-producer random delays, bursty producer,
+  and repeated single-message wake to detect lost-wake races.
+- `TestMultiTagBackoff`: multi-tag receive correctness — second-tag hit,
+  delayed arrival, per-tag FIFO ordering, timeout, and interleaved
+  producers.
+- `TestTimeoutAccuracy`: lower-bound / upper-bound wall-clock checks and
+  zero-timeout immediacy.
+- Added tests for duplicate cowns in `@when`: same cown twice, thrice,
+  non-adjacent duplicates, duplicates within a group, and mutation
+  aliasing semantics.
+
+**CI**
+
+- Added a `free-threaded` CI job that tests against Python 3.13t and
+  3.14t on Linux, with explicit assertions that the GIL remains disabled
+  after import.
+
 ## 2026-03-17 - Version 0.2.2
 Point release.
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,6 +5,6 @@ authors:
   given-names: "Matthew Alastair"
   orcid: "https://orcid.org/0000-0002-1019-8036"
 title: "bocpy"
-version: 0.2.2
-date-released: 2026-03-17
+version: 0.3.0
+date-released: 2026-04-01
 url: "https://github.com/microsoft/bocpy"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bocpy"
-version = "0.2.2"
+version = "0.3.0"
 authors = [
     {name = "bocpy Team", email="bocpy@microsoft.com"}
 ]

--- a/sphinx/source/conf.py
+++ b/sphinx/source/conf.py
@@ -14,7 +14,7 @@ import textwrap
 project = 'bocpy'
 copyright = '2026, Microsoft'
 author = 'Microsoft'
-release = '0.2.2'
+release = '0.3.0'
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/src/bocpy/_core.c
+++ b/src/bocpy/_core.c
@@ -42,25 +42,82 @@ void atomic_store(atomic_int_least64_t *ptr, int_least64_t value) {
   *ptr = value;
 }
 
+// All Interlocked* intrinsics on x86/x64 are full barriers, so the
+// memory_order argument is accepted but ignored.
+// Note: atomic_load_explicit is a plain volatile read. On x86/x64 this
+// provides acquire semantics due to TSO. Correctness of the parking
+// protocol relies on the mutex-protected re-check, not on seq_cst ordering.
+#define atomic_load_explicit(ptr, order) (*(ptr))
+#define atomic_fetch_add_explicit(ptr, val, order)                             \
+  InterlockedExchangeAdd64((ptr), (val))
+#define atomic_fetch_sub_explicit(ptr, val, order)                             \
+  InterlockedExchangeAdd64((ptr), -(val))
+#define memory_order_seq_cst 0
+
 #define thread_local __declspec(thread)
 
-#else
-#include <stdatomic.h>
-#endif
+typedef SRWLOCK BOCParkMutex;
+typedef CONDITION_VARIABLE BOCParkCond;
 
-#if defined __APPLE__
-#define thrd_sleep nanosleep
-#define thread_local _Thread_local
-#elif defined _WIN32
 void thrd_sleep(const struct timespec *duration, struct timespec *remaining) {
   const DWORD MS_PER_NS = 1000000;
   DWORD ms = (DWORD)duration->tv_sec * 1000;
   ms += (DWORD)duration->tv_nsec / MS_PER_NS;
   Sleep(ms);
 }
-#else
+
+#elif defined __APPLE__
+#include <pthread.h>
+#include <stdatomic.h>
+#define thrd_sleep nanosleep
+#define thread_local _Thread_local
+
+typedef pthread_mutex_t BOCParkMutex;
+typedef pthread_cond_t BOCParkCond;
+
+#else // Linux
+#include <stdatomic.h>
 #include <threads.h>
+
+typedef mtx_t BOCParkMutex;
+typedef cnd_t BOCParkCond;
+
 #endif
+
+// Forward declaration — BOCQueue is defined below.
+typedef struct boc_queue BOCQueue;
+
+/// @brief Initialize the park mutex and condition variable for a queue
+/// @param q The queue to initialize
+static inline void boc_park_init(BOCQueue *q);
+
+/// @brief Destroy the park mutex and condition variable for a queue
+/// @param q The queue to destroy
+static inline void boc_park_destroy(BOCQueue *q);
+
+/// @brief Lock the park mutex for a queue
+/// @param q The queue whose mutex to lock
+static inline void boc_park_lock(BOCQueue *q);
+
+/// @brief Unlock the park mutex for a queue
+/// @param q The queue whose mutex to unlock
+static inline void boc_park_unlock(BOCQueue *q);
+
+/// @brief Wake one thread parked on a queue's condition variable
+/// @note Caller MUST hold park_mutex
+/// @param q The queue to signal
+static inline void boc_park_signal(BOCQueue *q);
+
+/// @brief Wake all threads parked on a queue's condition variable
+/// @note Caller MUST hold park_mutex
+/// @param q The queue to broadcast
+static inline void boc_park_broadcast(BOCQueue *q);
+
+/// @brief Park the calling thread on a queue's condition variable
+/// @note Caller MUST hold park_mutex. The mutex is atomically released during
+/// the wait and re-acquired before returning.
+/// @param q The queue to park on
+static inline void boc_park_wait(BOCQueue *q);
 
 #if PY_VERSION_HEX >= 0x030D0000
 #define Py_BUILD_CORE
@@ -73,6 +130,17 @@ const int BOC_CAPACITY = 1024 * 16;
 const PY_INT64_T NO_OWNER = -2;
 atomic_int_least64_t BOC_COUNT = 0;
 atomic_int_least64_t BOC_COWN_COUNT = 0;
+
+#define BOC_SPIN_COUNT 64
+#define BOC_BACKOFF_CAP_NS 1000000 // 1 ms
+
+// Portable yield: relinquish current CPU timeslice.
+#ifdef _WIN32
+#define boc_yield() SwitchToThread()
+#else
+#include <sched.h>
+#define boc_yield() sched_yield()
+#endif
 
 // #define BOC_REF_TRACKING
 // #define BOC_TRACE
@@ -305,6 +373,13 @@ typedef struct boc_queue {
   /// queue. Calls to receive on the tag will attempt to dequeue from this
   /// queue.
   atomic_intptr_t tag; // (BOCTag *)
+
+  /// @brief Number of threads parked on this queue's condvar
+  atomic_int_least64_t waiters;
+  /// @brief Mutex protecting condvar signal/wait
+  BOCParkMutex park_mutex;
+  /// @brief Condition variable for parking receivers
+  BOCParkCond park_cond;
 } BOCQueue;
 
 /// @brief A tag for a BOC message.
@@ -326,6 +401,102 @@ const int_least64_t BOC_QUEUE_DISABLED = 2;
 static BOCQueue BOC_QUEUES[BOC_QUEUE_COUNT];
 static BOCRecycleQueue *BOC_RECYCLE_QUEUE_TAIL = NULL;
 static atomic_intptr_t BOC_RECYCLE_QUEUE_HEAD = 0;
+
+// ---------------------------------------------------------------------------
+// Platform condvar implementation
+// ---------------------------------------------------------------------------
+
+#ifdef _WIN32
+
+static inline void boc_park_init(BOCQueue *q) {
+  InitializeSRWLock(&q->park_mutex);
+  InitializeConditionVariable(&q->park_cond);
+}
+
+static inline void boc_park_destroy(BOCQueue *q) {
+  // Windows SRWLOCK and CONDITION_VARIABLE have no destroy function.
+  (void)q;
+}
+
+static inline void boc_park_lock(BOCQueue *q) {
+  AcquireSRWLockExclusive(&q->park_mutex);
+}
+
+static inline void boc_park_unlock(BOCQueue *q) {
+  ReleaseSRWLockExclusive(&q->park_mutex);
+}
+
+static inline void boc_park_signal(BOCQueue *q) {
+  WakeConditionVariable(&q->park_cond);
+}
+
+static inline void boc_park_broadcast(BOCQueue *q) {
+  WakeAllConditionVariable(&q->park_cond);
+}
+
+static inline void boc_park_wait(BOCQueue *q) {
+  SleepConditionVariableSRW(&q->park_cond, &q->park_mutex, INFINITE, 0);
+}
+
+#elif defined __APPLE__ // macOS — pthreads
+
+static inline void boc_park_init(BOCQueue *q) {
+  pthread_mutex_init(&q->park_mutex, NULL);
+  pthread_cond_init(&q->park_cond, NULL);
+}
+
+static inline void boc_park_destroy(BOCQueue *q) {
+  pthread_cond_destroy(&q->park_cond);
+  pthread_mutex_destroy(&q->park_mutex);
+}
+
+static inline void boc_park_lock(BOCQueue *q) {
+  pthread_mutex_lock(&q->park_mutex);
+}
+
+static inline void boc_park_unlock(BOCQueue *q) {
+  pthread_mutex_unlock(&q->park_mutex);
+}
+
+static inline void boc_park_signal(BOCQueue *q) {
+  pthread_cond_signal(&q->park_cond);
+}
+
+static inline void boc_park_broadcast(BOCQueue *q) {
+  pthread_cond_broadcast(&q->park_cond);
+}
+
+static inline void boc_park_wait(BOCQueue *q) {
+  pthread_cond_wait(&q->park_cond, &q->park_mutex);
+}
+
+#else // Linux — C11 threads
+
+static inline void boc_park_init(BOCQueue *q) {
+  mtx_init(&q->park_mutex, mtx_plain);
+  cnd_init(&q->park_cond);
+}
+
+static inline void boc_park_destroy(BOCQueue *q) {
+  cnd_destroy(&q->park_cond);
+  mtx_destroy(&q->park_mutex);
+}
+
+static inline void boc_park_lock(BOCQueue *q) { mtx_lock(&q->park_mutex); }
+
+static inline void boc_park_unlock(BOCQueue *q) { mtx_unlock(&q->park_mutex); }
+
+static inline void boc_park_signal(BOCQueue *q) { cnd_signal(&q->park_cond); }
+
+static inline void boc_park_broadcast(BOCQueue *q) {
+  cnd_broadcast(&q->park_cond);
+}
+
+static inline void boc_park_wait(BOCQueue *q) {
+  cnd_wait(&q->park_cond, &q->park_mutex);
+}
+
+#endif
 
 /// @brief Creates a new BOCTag object from a Python Unicode string.
 /// @details The result object will not be dependent on the argument in any way
@@ -955,12 +1126,22 @@ static void BOCRecycleQueue_recycle(BOCRecycleQueue *queue, XIDATA_T *xidata) {
   PyObject *xidata_ptr = PyLong_FromVoidPtr((void *)xidata);
 
   if (queue->xidata_to_cowns != NULL) {
+#if PY_VERSION_HEX >= 0x030D0000
+    PyObject *cown_ptr = NULL;
+    if (PyDict_GetItemRef(queue->xidata_to_cowns, xidata_ptr, &cown_ptr) > 0) {
+      BOCCown *cown = (BOCCown *)PyLong_AsVoidPtr(cown_ptr);
+      Py_DECREF(cown_ptr);
+      COWN_WEAK_DECREF(cown);
+      PyDict_DelItem(queue->xidata_to_cowns, xidata_ptr);
+    }
+#else
     PyObject *cown_ptr = PyDict_GetItem(queue->xidata_to_cowns, xidata_ptr);
     if (cown_ptr != NULL) {
       BOCCown *cown = (BOCCown *)PyLong_AsVoidPtr(cown_ptr);
       COWN_WEAK_DECREF(cown);
       PyDict_DelItem(queue->xidata_to_cowns, xidata_ptr);
     }
+#endif
   } else if (queue->index > 0) {
     fprintf(stderr,
             "Recycling xidata created on interpreter %" PRIdLEAST64
@@ -1328,6 +1509,57 @@ static PyObject *CownCapsule_release(PyObject *op, PyObject *Py_UNUSED(dummy)) {
   Py_RETURN_NONE;
 }
 
+/// @brief Abandons the cown value without serializing it
+/// @details Clears the value and resets ownership to NO_OWNER. This is used
+/// during worker cleanup to safely discard orphan cowns before the owning
+/// interpreter is destroyed.
+/// @param cown The cown to disown
+/// @return -1 if error, 0 otherwise
+static int cown_disown(BOCCown *cown) {
+  int_least64_t expected = get_interpid();
+  int_least64_t owner = atomic_load(&cown->owner);
+  if (owner != expected) {
+    PyErr_Format(PyExc_RuntimeError,
+                 "%" PRIdLEAST64
+                 " cannot disown cown (acquired by %" PRIdLEAST64 ")",
+                 expected, owner);
+    return -1;
+  }
+
+  assert(cown->value != NULL);
+  assert(cown->xidata == NULL);
+
+  Py_CLEAR(cown->value);
+
+  int_least64_t desired = NO_OWNER;
+  if (!atomic_compare_exchange_strong(&cown->owner, &expected, desired)) {
+    PyErr_SetString(PyExc_RuntimeError,
+                    "Panic: contention on cown during disown");
+    return -1;
+  }
+
+  return 0;
+}
+
+/// @brief Abandons the cown
+/// @note Clears the value without serializing and resets ownership. Used during
+/// worker shutdown to avoid dangling pointers after interpreter destruction.
+/// Will raise an error if the cown is not currently acquired by this
+/// interpreter.
+/// @param op The CownCapsule object
+/// @param Py_UNUSED (ignored)
+/// @return None if successful, NULL otherwise
+static PyObject *CownCapsule_disown(PyObject *op, PyObject *Py_UNUSED(dummy)) {
+  CownCapsuleObject *self = (CownCapsuleObject *)op;
+  BOCCown *cown = self->cown;
+
+  if (cown_disown(cown) < 0) {
+    return NULL;
+  }
+
+  Py_RETURN_NONE;
+}
+
 static PyObject *CownCapsule_get_impl(PyObject *op, void *Py_UNUSED(dummy)) {
   return Py_NewRef(op);
 }
@@ -1338,6 +1570,7 @@ static PyMethodDef CownCapsule_methods[] = {
     {"acquired", CownCapsule_acquired, METH_NOARGS, NULL},
     {"acquire", CownCapsule_acquire, METH_NOARGS, NULL},
     {"release", CownCapsule_release, METH_NOARGS, NULL},
+    {"disown", CownCapsule_disown, METH_NOARGS, NULL},
     {NULL} /* Sentinel */
 };
 
@@ -1757,6 +1990,11 @@ static BOCQueue *get_queue_for_tag(PyObject *tag) {
     }
 
     // this queue has already been assigned
+    if (expected == BOC_QUEUE_DISABLED) {
+      // queue is being reconfigured by set_tags — skip it
+      continue;
+    }
+
     BOCTag *qtag = (BOCTag *)atomic_load(&qptr->tag);
     while (qtag == NULL) {
       // waiting for another interpreter to allocate and assign
@@ -1769,11 +2007,6 @@ static BOCQueue *get_queue_for_tag(PyObject *tag) {
     PRINTDBG("Discovered %s at queue %" PRIdLEAST64 "\n", qtag->str, i);
     if (tag_compare_with_PyUnicode(BOC_STATE->queue_tags[i], tag) == 0) {
       // this is the dedicated queue for this tag
-      if (expected == BOC_QUEUE_DISABLED) {
-        // however, it is disabled right now
-        return NULL;
-      }
-
       return qptr;
     } else if (PyErr_Occurred() != NULL) {
       return NULL;
@@ -1860,6 +2093,17 @@ static int boc_enqueue(BOCMessage *message) {
                tail - head + 1);
       assert(qptr->messages[tail % BOC_CAPACITY] == NULL);
       qptr->messages[tail % BOC_CAPACITY] = message;
+
+      // If any receiver is parked on this queue's condvar, wake it.
+      // The seq_cst load synchronizes with the consumer's seq_cst increment
+      // of waiters, ensuring that either we see the waiter and signal, or the
+      // consumer's re-check dequeue (under the same mutex) finds our message.
+      if (atomic_load_explicit(&qptr->waiters, memory_order_seq_cst) > 0) {
+        boc_park_lock(qptr);
+        boc_park_signal(qptr);
+        boc_park_unlock(qptr);
+      }
+
       return 0;
     }
 
@@ -1965,10 +2209,227 @@ static PyObject *_core_send(PyObject *module, PyObject *args) {
     return NULL;
   }
 
-  Py_BEGIN_ALLOW_THREADS thrd_sleep(&SLEEP_TS, NULL);
+  Py_BEGIN_ALLOW_THREADS;
+  boc_yield();
   Py_END_ALLOW_THREADS;
 
   Py_RETURN_NONE;
+}
+
+/// @brief Double the exponential backoff duration, capped at BOC_BACKOFF_CAP_NS
+/// @param backoff The timespec whose tv_nsec field will be doubled
+static inline void boc_backoff_double(struct timespec *backoff) {
+  backoff->tv_nsec *= 2;
+  if (backoff->tv_nsec > BOC_BACKOFF_CAP_NS) {
+    backoff->tv_nsec = BOC_BACKOFF_CAP_NS;
+  }
+}
+
+/// @brief Wake any receivers parked on the queue associated with a tag
+/// @param tag The tag whose queue should be signalled (borrowed reference)
+static inline void boc_wake_parked_receivers(PyObject *tag) {
+  BOCQueue *qptr = get_queue_for_tag(tag);
+  if (qptr != NULL &&
+      atomic_load_explicit(&qptr->waiters, memory_order_seq_cst) > 0) {
+    boc_park_lock(qptr);
+    boc_park_broadcast(qptr);
+    boc_park_unlock(qptr);
+  }
+}
+
+/// @brief Receives a message on a single tag using spin-then-park (untimed) or
+/// spin-then-backoff (timed)
+/// @param tag The tag to receive on (borrowed reference)
+/// @param do_timeout Whether a timeout was requested
+/// @param end_time Deadline as double-precision seconds (only if do_timeout)
+/// @param after Callback to invoke on timeout (or Py_None)
+/// @return The received (tag, contents) tuple, timeout sentinel, or NULL on
+/// error
+static PyObject *receive_single_tag(PyObject *tag, bool do_timeout,
+                                    double end_time, PyObject *after) {
+  BOCQueue *qptr = get_queue_for_tag(tag);
+  BOCMessage *message = NULL;
+  struct timespec backoff = {0, 1000}; // 1 µs, only used when do_timeout
+
+  while (true) {
+    // Phase 1: Spin
+    for (int spin = 0; spin < BOC_SPIN_COUNT; ++spin) {
+      BOCRecycleQueue_empty(BOC_STATE->recycle_queue, false);
+
+      int_least64_t queue_index = boc_dequeue(tag, &message);
+      if (queue_index >= 0) {
+        goto got_message;
+      }
+
+      if (PyErr_Occurred() != NULL) {
+        return NULL;
+      }
+
+      if (do_timeout && boc_now_s() > end_time) {
+        goto timed_out;
+      }
+    }
+
+    // Phase 2a: Timed — exponential backoff (no parking)
+    if (do_timeout) {
+      if (boc_now_s() > end_time) {
+        goto timed_out;
+      }
+
+      Py_BEGIN_ALLOW_THREADS;
+      thrd_sleep(&backoff, NULL);
+      Py_END_ALLOW_THREADS;
+
+      boc_backoff_double(&backoff);
+
+      continue;
+    }
+
+    // Phase 2b: Untimed — park on condvar (indefinite wait)
+    if (qptr == NULL) {
+      PyErr_SetString(PyExc_KeyError, "No message queue found for that tag");
+      return NULL;
+    }
+
+    boc_park_lock(qptr);
+    // seq_cst increment synchronizes with the seq_cst load in boc_enqueue,
+    // ensuring that either the producer sees our waiter count and signals,
+    // or our re-check dequeue below finds the producer's message.
+    atomic_fetch_add_explicit(&qptr->waiters, 1, memory_order_seq_cst);
+
+    // Re-check under lock (prevents lost wake)
+    int_least64_t queue_index = boc_dequeue(tag, &message);
+    if (queue_index >= 0) {
+      atomic_fetch_sub_explicit(&qptr->waiters, 1, memory_order_seq_cst);
+      boc_park_unlock(qptr);
+      goto got_message;
+    }
+
+    if (PyErr_Occurred() != NULL) {
+      atomic_fetch_sub_explicit(&qptr->waiters, 1, memory_order_seq_cst);
+      boc_park_unlock(qptr);
+      return NULL;
+    }
+
+    Py_BEGIN_ALLOW_THREADS;
+    boc_park_wait(qptr);
+    // Wake: we hold park_mutex but NOT the GIL.
+    // Release mutex BEFORE re-acquiring GIL to avoid ABBA deadlock:
+    // consumer (mutex → GIL) vs producer (GIL → mutex).
+    atomic_fetch_sub_explicit(&qptr->waiters, 1, memory_order_seq_cst);
+    boc_park_unlock(qptr);
+    Py_END_ALLOW_THREADS;
+
+    // Re-resolve queue pointer (set_tags may have reassigned it)
+    BOCQueue *new_qptr = get_queue_for_tag(tag);
+    if (new_qptr == NULL) {
+      PyErr_SetString(PyExc_RuntimeError, "Tag invalidated during receive");
+      return NULL;
+    }
+
+    if (new_qptr != qptr) {
+      qptr = new_qptr;
+    }
+
+    BOCRecycleQueue_empty(BOC_STATE->recycle_queue, false);
+  }
+
+got_message:;
+#ifdef BOC_TRACE
+  if (tag_compare_with_PyUnicode(message->tag, tag) != 0) {
+    if (PyErr_Occurred() != NULL) {
+      boc_message_free(message);
+      return NULL;
+    }
+  }
+#endif
+
+  PyObject *contents = xidata_to_object(message->xidata, message->pickled);
+  if (contents == NULL) {
+    boc_message_free(message);
+    return NULL;
+  }
+
+  PyObject *result = PyTuple_Pack(2, tag, contents);
+  Py_DECREF(contents);
+  boc_message_free(message);
+  return result;
+
+timed_out:
+  if (!Py_IsNone(after)) {
+    return PyObject_CallNoArgs(after);
+  }
+  return Py_BuildValue("(sO)", BOC_TIMEOUT, Py_None);
+}
+
+/// @brief Receives a message on multiple tags using round-robin with
+/// exponential backoff
+/// @param tags_fast A PySequence_Fast of tag strings (borrowed reference)
+/// @param tags_size The number of tags
+/// @param do_timeout Whether a timeout was requested
+/// @param end_time Deadline as double-precision seconds (only if do_timeout)
+/// @param after Callback to invoke on timeout (or Py_None)
+/// @return The received (tag, contents) tuple, timeout sentinel, or NULL on
+/// error
+static PyObject *receive_multi_tag(PyObject *tags_fast, Py_ssize_t tags_size,
+                                   bool do_timeout, double end_time,
+                                   PyObject *after) {
+  BOCMessage *message = NULL;
+  size_t tag_index = 0;
+  struct timespec backoff = {0, 1000}; // 1 µs
+
+  while (true) {
+    BOCRecycleQueue_empty(BOC_STATE->recycle_queue, false);
+
+    // Round-robin: try one tag per iteration
+    PyObject *tag = PySequence_Fast_GET_ITEM(tags_fast, tag_index);
+    tag_index = (tag_index + 1) % tags_size;
+
+    int_least64_t queue_index = boc_dequeue(tag, &message);
+    if (queue_index >= 0) {
+#ifdef BOC_TRACE
+      if (tag_compare_with_PyUnicode(message->tag, tag) != 0) {
+        if (PyErr_Occurred() != NULL) {
+          boc_message_free(message);
+          Py_DECREF(tags_fast);
+          return NULL;
+        }
+      }
+#endif
+
+      PyObject *contents = xidata_to_object(message->xidata, message->pickled);
+      if (contents == NULL) {
+        boc_message_free(message);
+        Py_DECREF(tags_fast);
+        return NULL;
+      }
+
+      PyObject *result = PyTuple_Pack(2, tag, contents);
+      Py_DECREF(contents);
+      boc_message_free(message);
+      Py_DECREF(tags_fast);
+      return result;
+    }
+
+    if (PyErr_Occurred() != NULL) {
+      Py_DECREF(tags_fast);
+      return NULL;
+    }
+
+    if (do_timeout && boc_now_s() > end_time) {
+      Py_DECREF(tags_fast);
+      if (!Py_IsNone(after)) {
+        return PyObject_CallNoArgs(after);
+      }
+      return Py_BuildValue("(sO)", BOC_TIMEOUT, Py_None);
+    }
+
+    Py_BEGIN_ALLOW_THREADS;
+    thrd_sleep(&backoff, NULL);
+    Py_END_ALLOW_THREADS;
+
+    boc_backoff_double(&backoff);
+  }
 }
 
 /// @brief Receives a message
@@ -2035,8 +2496,6 @@ static PyObject *_core_receive(PyObject *module, PyObject *args,
     }
   }
 
-  // determine if a timeout has been requested, and what clock time that would
-  // be
   bool do_timeout = false;
   double end_time = 0;
   if (timeout >= 0) {
@@ -2044,75 +2503,12 @@ static PyObject *_core_receive(PyObject *module, PyObject *args,
     end_time = boc_now_s() + timeout;
   }
 
-  size_t tag_index = 0;
-  BOCMessage *message = NULL;
-  while (true) {
-    Py_BEGIN_ALLOW_THREADS thrd_sleep(&SLEEP_TS, NULL);
-    Py_END_ALLOW_THREADS;
-
-    BOCRecycleQueue_empty(BOC_STATE->recycle_queue, false);
-
-    int_least64_t queue_index = -1;
-
-    if (tags_fast != NULL) {
-      // see if there are available messages for any of the tags
-      tag = PySequence_Fast_GET_ITEM(tags_fast, tag_index);
-      queue_index = boc_dequeue(tag, &message);
-      tag_index = (tag_index + 1) % tags_size;
-    } else {
-      queue_index = boc_dequeue(tag, &message);
-    }
-
-    if (queue_index < 0) {
-      if (PyErr_Occurred() != NULL) {
-        assert(message == NULL);
-        Py_XDECREF(tags_fast);
-        return NULL;
-      }
-
-      // no message was available
-      if (do_timeout && boc_now_s() > end_time) {
-        // we've timed out
-        if (!Py_IsNone(after)) {
-          return PyObject_CallNoArgs(after);
-        }
-
-        return Py_BuildValue("(sO)", BOC_TIMEOUT, Py_None);
-      }
-
-      continue;
-    }
-
-#ifdef BOC_TRACE
-    if (tag_compare_with_PyUnicode(message->tag, tag) != 0) {
-      // this should not happen, and indicates a bug in
-      // boc_enqueue()/boc_dequeue()
-      if (PyErr_Occurred() != NULL) {
-        Py_XDECREF(tags_fast);
-        boc_message_free(message);
-        return NULL;
-      }
-
-      continue;
-    }
-#endif
-
-    PyObject *contents = xidata_to_object(message->xidata, message->pickled);
-    if (contents == NULL) {
-      Py_XDECREF(tags_fast);
-      boc_message_free(message);
-      return NULL;
-    }
-
-    PyObject *result = PyTuple_Pack(2, tag, contents);
-    Py_DECREF(contents);
-
-    boc_message_free(message);
-    Py_XDECREF(tags_fast);
-    return result;
+  // Dispatch: single-tag vs multi-tag
+  if (tags_fast != NULL) {
+    return receive_multi_tag(tags_fast, tags_size, do_timeout, end_time, after);
   }
 
-  Py_RETURN_NONE;
+  return receive_single_tag(tag, do_timeout, end_time, after);
 }
 
 /// @brief Drain all the messages associated with a particular tag
@@ -2141,6 +2537,8 @@ PyObject *_core_drain(PyObject *module, PyObject *args) {
 
       boc_message_free(message);
     }
+
+    boc_wake_parked_receivers(tags);
 
     Py_RETURN_NONE;
   }
@@ -2182,6 +2580,8 @@ PyObject *_core_drain(PyObject *module, PyObject *args) {
 
       boc_message_free(message);
     }
+
+    boc_wake_parked_receivers(tag);
   }
 
   Py_DECREF(tags_fast);
@@ -3222,6 +3622,16 @@ static PyObject *_core_set_tags(PyObject *module, PyObject *args) {
     }
   }
 
+  // Wake any receivers parked on condvars so they re-resolve their tags
+  qptr = BOC_QUEUES;
+  for (Py_ssize_t i = 0; i < BOC_QUEUE_COUNT; ++i, ++qptr) {
+    if (atomic_load_explicit(&qptr->waiters, memory_order_seq_cst) > 0) {
+      boc_park_lock(qptr);
+      boc_park_broadcast(qptr);
+      boc_park_unlock(qptr);
+    }
+  }
+
   Py_RETURN_NONE;
 }
 
@@ -3257,6 +3667,8 @@ static int _core_module_exec(PyObject *module) {
       qptr->tail = 0;
       qptr->state = BOC_QUEUE_UNASSIGNED;
       qptr->tag = 0;
+      qptr->waiters = 0;
+      boc_park_init(qptr);
     }
 
     BOCRecycleQueue *queue_stub =
@@ -3377,6 +3789,7 @@ void _core_module_free(void *module_ptr) {
     BOCQueue *qptr = BOC_QUEUES;
     for (size_t i = 0; i < BOC_QUEUE_COUNT; ++i, ++qptr) {
       PyMem_RawFree(qptr->messages);
+      boc_park_destroy(qptr);
 
       if (atomic_load(&qptr->state) == BOC_QUEUE_ASSIGNED) {
         BOCTag *qtag = (BOCTag *)atomic_load(&qptr->tag);
@@ -3417,6 +3830,9 @@ static PyModuleDef_Slot _core_module_slots[] = {
     {Py_mod_exec, (void *)_core_module_exec},
 #if PY_VERSION_HEX >= 0x030C0000
     {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
+#endif
+#if PY_VERSION_HEX >= 0x030D0000
+    {Py_mod_gil, Py_MOD_GIL_NOT_USED},
 #endif
     {0, NULL},
 };

--- a/src/bocpy/_math.c
+++ b/src/bocpy/_math.c
@@ -2577,6 +2577,9 @@ static PyModuleDef_Slot _math_module_slots[] = {
 #if PY_VERSION_HEX >= 0x030C0000
     {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
 #endif
+#if PY_VERSION_HEX >= 0x030D0000
+    {Py_mod_gil, Py_MOD_GIL_NOT_USED},
+#endif
     {0, NULL},
 };
 #endif

--- a/src/bocpy/behaviors.py
+++ b/src/bocpy/behaviors.py
@@ -152,7 +152,17 @@ class Behavior:
         self.impl = impl
         self.bid = impl.bid()
         self.thunk = impl.thunk()
-        self.requests = [Request(req_impl) for req_impl in impl.create_requests()]
+        seen = set()
+        self.requests = []
+        for req_impl in impl.create_requests():
+            r = Request(req_impl)
+            if r.target() in seen:
+                # Duplicate cown: compensate behavior count since this request
+                # won't enter the MCS queue and thus won't call resolve_one.
+                self.impl.resolve_one()
+            else:
+                seen.add(r.target())
+                self.requests.append(r)
         self.requests.sort(key=lambda r: r.target())
 
     def schedule(self):

--- a/src/bocpy/worker.py
+++ b/src/bocpy/worker.py
@@ -88,6 +88,7 @@ def cleanup():
             for cown in orphan_cowns:
                 if cown is not None:
                     cown.acquire()
+                    cown.disown()
 
         orphan_cowns = None
         _core.recycle()

--- a/test/test_boc.py
+++ b/test/test_boc.py
@@ -394,3 +394,75 @@ class TestBOC:
             send("assert", (sorted(a.value.items), list(range(10))))
 
         self.receive_asserts()
+
+    def test_duplicate_cown_same_twice(self):
+        """Same cown passed twice to @when completes without deadlock."""
+        c = Cown(5)
+
+        @when(c, c)
+        def add(a, b):
+            return a.value + b.value
+
+        @when(add)
+        def check(r):
+            send("assert", (r.value, 10))
+
+        self.receive_asserts()
+
+    def test_duplicate_cown_same_thrice(self):
+        """Same cown passed three times to @when completes without deadlock."""
+        c = Cown(3)
+
+        @when(c, c, c)
+        def triple(a, b, d):
+            return a.value + b.value + d.value
+
+        @when(triple)
+        def check(r):
+            send("assert", (r.value, 9))
+
+        self.receive_asserts()
+
+    def test_duplicate_cown_non_adjacent(self):
+        """Non-adjacent duplicate cowns in @when complete correctly."""
+        a = Cown(10)
+        b = Cown(20)
+
+        @when(a, b, a)
+        def mixed(x, y, z):
+            return x.value + y.value + z.value
+
+        @when(mixed)
+        def check(r):
+            send("assert", (r.value, 40))
+
+        self.receive_asserts()
+
+    def test_duplicate_cown_in_group(self):
+        """Duplicate cowns within a group complete without deadlock."""
+        c = Cown(7)
+
+        @when([c, c])
+        def group_sum(group):
+            return sum(g.value for g in group)
+
+        @when(group_sum)
+        def check(r):
+            send("assert", (r.value, 14))
+
+        self.receive_asserts()
+
+    def test_duplicate_cown_mutation(self):
+        """Mutating a cown passed twice reflects same underlying value."""
+        c = Cown(1)
+
+        @when(c, c)
+        def mutate(a, b):
+            a.value = 42
+            return b.value
+
+        @when(mutate)
+        def check(r):
+            send("assert", (r.value, 42))
+
+        self.receive_asserts()

--- a/test/test_message_queue.py
+++ b/test/test_message_queue.py
@@ -16,6 +16,7 @@ the auto-assignment path and use a ``set_tags([])`` call only in the fixture to
 ensure a clean slate.
 """
 
+import random
 import threading
 import time
 
@@ -767,3 +768,190 @@ class TestDrain:
         """Passing non-string elements in the tag list raises TypeError."""
         with pytest.raises(TypeError):
             drain([123])
+
+
+# ===================================================================
+# Spin-then-park: lost-wake stress
+# ===================================================================
+
+
+class TestLostWakeStress:
+    """Verify that the spin-then-park strategy never loses a wake signal."""
+
+    def test_single_producer_random_delays(self):
+        """One slow producer, one consumer — consumer must never hang."""
+        n = 200
+
+        def producer():
+            for i in range(n):
+                if random.random() < 0.3:
+                    time.sleep(random.uniform(0.0001, 0.005))
+                send("lw_rand", i)
+
+        t = threading.Thread(target=producer)
+        t.start()
+
+        for i in range(n):
+            tag, val = receive("lw_rand", 10)
+            assert tag == "lw_rand", f"Timed out waiting for message {i}"
+            assert val == i
+
+        t.join()
+
+    def test_bursty_producer(self):
+        """Producer sends bursts with pauses — consumer must not deadlock."""
+        bursts = 10
+        per_burst = 50
+
+        def producer():
+            for b in range(bursts):
+                for i in range(per_burst):
+                    send("lw_burst", b * per_burst + i)
+                time.sleep(random.uniform(0.005, 0.02))
+
+        t = threading.Thread(target=producer)
+        t.start()
+
+        total = bursts * per_burst
+        for i in range(total):
+            tag, val = receive("lw_burst", 10)
+            assert tag == "lw_burst", f"Timed out at message {i}"
+            assert val == i
+
+        t.join()
+
+    @pytest.mark.parametrize("iteration", range(20))
+    def test_single_message_wake(self, iteration):
+        """A single message wakes a parked consumer — repeated to catch races."""
+        def delayed_send():
+            time.sleep(random.uniform(0.001, 0.01))
+            send("lw_single", iteration)
+
+        t = threading.Thread(target=delayed_send)
+        t.start()
+        tag, val = receive("lw_single", 5)
+        t.join()
+        assert tag == "lw_single"
+        assert val == iteration
+
+
+# ===================================================================
+# Spin-then-park: multi-tag receive
+# ===================================================================
+
+
+class TestMultiTagBackoff:
+    """Multi-tag receive correctness under the exponential backoff path."""
+
+    def test_message_on_second_tag(self):
+        """Multi-tag receive finds a message on a non-first tag."""
+        send("mtb_b", "found")
+        tag, val = receive(["mtb_a", "mtb_b", "mtb_c"], 5)
+        assert tag == "mtb_b"
+        assert val == "found"
+
+    def test_multi_tag_delayed_arrival(self):
+        """Multi-tag receive waits for a message arriving after a delay."""
+        def delayed_send():
+            time.sleep(0.05)
+            send("mtd_c", "late")
+
+        t = threading.Thread(target=delayed_send)
+        t.start()
+        tag, val = receive(["mtd_a", "mtd_b", "mtd_c"], 5)
+        t.join()
+        assert tag == "mtd_c"
+        assert val == "late"
+
+    def test_multi_tag_fifo_per_tag(self):
+        """Multi-tag receive preserves per-tag FIFO ordering."""
+        for i in range(5):
+            send("mf_x", ("x", i))
+            send("mf_y", ("y", i))
+
+        results = {"mf_x": [], "mf_y": []}
+        for _ in range(10):
+            tag, val = receive(["mf_x", "mf_y"], 5)
+            results[tag].append(val[1])
+
+        assert results["mf_x"] == list(range(5))
+        assert results["mf_y"] == list(range(5))
+
+    def test_multi_tag_timeout(self):
+        """Multi-tag receive times out when no message arrives."""
+        tag, val = receive(["mtt_a", "mtt_b"], 0.1)
+        assert tag == TIMEOUT
+        assert val is None
+
+    def test_multi_tag_interleaved_producers(self):
+        """Multiple producers on different tags, multi-tag consumer."""
+        n = 100
+
+        def producer(tag, offset):
+            for i in range(n):
+                if random.random() < 0.2:
+                    time.sleep(random.uniform(0.0001, 0.002))
+                send(tag, offset + i)
+
+        tags = ["mti_a", "mti_b", "mti_c"]
+        threads = [threading.Thread(target=producer, args=(t, i * n))
+                   for i, t in enumerate(tags)]
+        for t in threads:
+            t.start()
+
+        received = []
+        for _ in range(len(tags) * n):
+            tag, val = receive(tags, 10)
+            assert tag in tags
+            received.append((tag, val))
+
+        for t in threads:
+            t.join()
+
+        per_tag = {t: [] for t in tags}
+        for tag, val in received:
+            per_tag[tag].append(val)
+
+        for i, t in enumerate(tags):
+            expected = [i * n + j for j in range(n)]
+            assert sorted(per_tag[t]) == expected
+
+
+# ===================================================================
+# Spin-then-park: timeout accuracy
+# ===================================================================
+
+
+class TestTimeoutAccuracy:
+    """Verify that timed receives return within a reasonable time window."""
+
+    @pytest.mark.parametrize("timeout", [0.05, 0.1, 0.2])
+    def test_timeout_lower_bound(self, timeout):
+        """Receive does not return before the timeout elapses."""
+        start = time.monotonic()
+        tag, _ = receive("ta_lower", timeout)
+        elapsed = time.monotonic() - start
+        assert tag == TIMEOUT
+        assert elapsed >= timeout * 0.9, (
+            f"Returned too early: {elapsed:.4f}s < {timeout * 0.9:.4f}s"
+        )
+
+    @pytest.mark.parametrize("timeout", [0.05, 0.1, 0.2])
+    def test_timeout_upper_bound(self, timeout):
+        """Receive returns within a generous upper bound of the timeout."""
+        start = time.monotonic()
+        tag, _ = receive("ta_upper", timeout)
+        elapsed = time.monotonic() - start
+        assert tag == TIMEOUT
+        upper = timeout + 0.1  # 100 ms grace for scheduling jitter
+        assert elapsed <= upper, (
+            f"Returned too late: {elapsed:.4f}s > {upper:.4f}s"
+        )
+
+    def test_zero_timeout_immediate(self):
+        """Zero timeout returns immediately (sub-millisecond)."""
+        start = time.monotonic()
+        tag, _ = receive("ta_zero", 0)
+        elapsed = time.monotonic() - start
+        assert tag == TIMEOUT
+        assert elapsed < 0.01, f"Zero timeout took {elapsed:.4f}s"


### PR DESCRIPTION
Spin-then-park receive; free-threaded Python compatibility.

**Improvements**

- Added `CownCapsule.disown()` — abandons a cown's value without
  serializing it and resets ownership to `NO_OWNER`. Used during worker
  cleanup to safely discard orphan cowns before the owning interpreter
  is destroyed, preventing dangling Python object references.
- Rewrote `receive` to use a two-phase spin-then-park strategy for
  single-tag untimed receives. Phase 1 spins for `BOC_SPIN_COUNT`
  iterations; Phase 2 parks the thread on a per-queue condvar, eliminating
  busy-wait CPU burn. Timed receives and multi-tag receives use
  spin-then-backoff with exponential sleep (1 µs → 1 ms cap).
- Added platform-abstracted condvar primitives (`BOCParkMutex` /
  `BOCParkCond`) with implementations for Windows (SRWLOCK /
  CONDITION_VARIABLE), macOS (pthreads), and Linux (C11 threads).
- Each `BOCQueue` now carries a `waiters` counter, `park_mutex`, and
  `park_cond`. Producers signal parked receivers after enqueue;
  `drain` and `set_tags` broadcast to wake all parked threads.
- Replaced the fixed `thrd_sleep` in `send` with a `sched_yield` /
  `SwitchToThread`, reducing send-side latency.
- Refactored the monolithic `_core_receive` into `receive_single_tag`
  and `receive_multi_tag`, each with its own backoff/parking logic.
- Moved the `BOC_QUEUE_DISABLED` check earlier in `get_queue_for_tag`
  so callers skip disabled queues instead of returning NULL after
  tag resolution.
- Added Windows-compatible `atomic_load_explicit` /
  `atomic_fetch_add_explicit` / `atomic_fetch_sub_explicit` macros
  using `InterlockedExchangeAdd64`.
- Declared `Py_mod_gil = Py_MOD_GIL_NOT_USED` in both `_core` and
  `_math` C extensions so that importing bocpy on a free-threaded
  Python build (3.13t+) does not re-enable the GIL.
- Replaced `PyDict_GetItem` (borrowed reference) with
  `PyDict_GetItemRef` (strong reference) in `BOCRecycleQueue_recycle`
  on Python 3.13+, improving forward-compatibility with free-threaded
  builds.

**Bug Fixes**

- Fixed a deadlock when the same cown is passed multiple times to `@when`
  (e.g. `@when(c, c)`). Duplicate requests for the same cown caused the
  MCS-queue-based two-phase locking to spin-wait on itself. Requests are
  now deduplicated by target cown in `Behavior.__init__`, with
  compensating `resolve_one` calls to maintain the behavior count
  invariant.

**Tests**

- `TestLostWakeStress`: single-producer random delays, bursty producer,
  and repeated single-message wake to detect lost-wake races.
- `TestMultiTagBackoff`: multi-tag receive correctness — second-tag hit,
  delayed arrival, per-tag FIFO ordering, timeout, and interleaved
  producers.
- `TestTimeoutAccuracy`: lower-bound / upper-bound wall-clock checks and
  zero-timeout immediacy.
- Added tests for duplicate cowns in `@when`: same cown twice, thrice,
  non-adjacent duplicates, duplicates within a group, and mutation
  aliasing semantics.

**CI**

- Added a `free-threaded` CI job that tests against Python 3.13t and
  3.14t on Linux, with explicit assertions that the GIL remains disabled
  after import.