### PR TITLE
CownCapsule serialization support for nested cowns.

### DIFF
--- a/.github/skills/multi-perspective-plan/SKILL.md
+++ b/.github/skills/multi-perspective-plan/SKILL.md
@@ -1,13 +1,14 @@
 ---
 name: multi-perspective-plan
-description: "Multi-perspective planning with adversarial review. Use when: planning complex changes, designing architecture, evaluating implementation strategies, drafting implementation plans, or when /plan is invoked. Spawns four subagents with competing priorities (speed, usability, conservatism, adversarial) then synthesizes their outputs into a balanced final plan."
+description: "Multi-perspective planning with adversarial review loop. Use when: planning complex changes, designing architecture, evaluating implementation strategies, drafting implementation plans, or when /plan is invoked. Spawns three planner subagents, synthesizes their outputs, then iteratively hardens the plan through an adversarial review loop until it passes scrutiny."
 argument-hint: "Describe the change or feature to plan"
 ---
 
 # Multi-Perspective Planning
 
-Generate a robust implementation plan by soliciting four competing viewpoints
-and synthesizing them into a single balanced proposal.
+Generate a robust implementation plan by soliciting three competing viewpoints,
+synthesizing them, and then hardening the result through an adversarial review
+loop.
 
 ## When to Use
 
@@ -24,18 +25,17 @@ subagent can work from the same facts. Read the relevant source files and tests.
 Summarize the current state in a brief context block that will be included in
 every subagent prompt.
 
-### 2. Spawn Four Planner Subagents
+### 2. Spawn Three Planner Subagents
 
-Launch four subagents **in parallel**. Each receives the same context block plus
-a persona directive. Each must return a concrete, step-by-step implementation
-plan (not just commentary).
+Launch three subagents **in parallel**. Each receives the same context block
+plus a persona directive. Each must return a concrete, step-by-step
+implementation plan (not just commentary).
 
 | # | Persona | Directive |
 |---|---------|-----------|
 | 1 | **Speed** | Obsessed with performance. Minimize latency and overhead at all costs. Inline aggressively, avoid abstractions, prefer lock-free and wait-free primitives. Tolerate complexity if it buys speed. |
 | 2 | **Usability** | Prioritize clean, readable, maintainable code. Favor clear abstractions, good naming, and small functions. Accept modest performance cost for clarity. |
 | 3 | **Conservative** | Minimize the changeset. Touch as few lines as possible. Prefer surgical edits over refactors. Reuse existing patterns. Resist new dependencies or abstractions. |
-| 4 | **Adversarial** | Assume the plan is wrong. Actively try to break the design. Look for race conditions, deadlocks, ABA problems, platform bugs, edge cases, and failure modes. Start from skepticism and only endorse what survives scrutiny. |
 
 Each subagent prompt must include:
 
@@ -44,28 +44,94 @@ Each subagent prompt must include:
 - A request for a **numbered step-by-step plan** with rationale per step
 - A request for **risks and mitigations** specific to their perspective
 
-### 3. Review the Four Plans
+### 3. Review the Three Plans
 
-After all four subagents return, review their outputs yourself. Write a brief
+After all three subagents return, review their outputs yourself. Write a brief
 analysis noting:
 
 - Points of agreement (high-confidence decisions)
 - Points of disagreement (trade-offs to resolve)
-- Risks raised by the adversarial planner that others missed
 - Any gaps none of the planners addressed
 
 ### 4. Synthesize
 
-Send all four plans **plus your analysis** to a fifth subagent with the
+Send all three plans **plus your analysis** to a fourth subagent with the
 directive:
 
-> You are a senior engineer synthesizing four competing implementation plans
+> You are a senior engineer synthesizing three competing implementation plans
 > into one final plan. Preserve the strongest ideas from each perspective.
 > Where planners disagree, make an explicit trade-off decision and justify it.
 > The final plan must be a numbered step-by-step implementation sequence with
 > clear rationale. Flag any unresolved risks.
 
-### 5. Present
+The output of this step is the **draft plan**.
 
-Present the synthesized plan to the user for approval. Clearly attribute which
-ideas came from which perspective where relevant.
+### 5. Adversarial Review Loop
+
+Iteratively harden the draft plan by running adversarial reviews until the plan
+passes scrutiny. Each iteration proceeds as follows:
+
+#### 5a. Spawn Adversarial Reviewer
+
+Launch a fresh subagent with the directive:
+
+> You are an adversarial reviewer. Assume this plan is wrong. Actively try to
+> break the design. Look for race conditions, deadlocks, ABA problems, platform
+> bugs, edge cases, missing error handling, reference counting errors, and
+> failure modes. Start from skepticism and only endorse what survives scrutiny.
+>
+> **Plan to review:**
+> {include the full draft plan}
+>
+> **Codebase context:**
+> {include the shared context block from step 1}
+>
+> **Instructions:**
+> - For each issue found, report it in this exact format:
+>
+>   **[SEVERITY] Short title**
+>   - **Location:** plan step number
+>   - **Problem:** what is wrong and why it matters
+>   - **Suggestion:** concrete fix or remediation
+>
+>   where SEVERITY is one of: critical, high, medium, low.
+>
+> - If the plan survives your scrutiny, state explicitly: "LGTM — no issues
+>   found."
+> - Do NOT fabricate issues. Only report genuine problems.
+> - Order findings by severity (critical first).
+
+#### 5b. Evaluate Findings
+
+After the adversarial reviewer returns:
+
+- If the reviewer reports **"LGTM"** (no issues found), the plan is final.
+  Proceed to step 6.
+- If the reviewer reports findings, address them:
+  - For **critical** and **high** findings: revise the plan to fix or mitigate
+    each issue. Update the draft plan in-place.
+  - For **medium** findings: revise if the fix is straightforward; otherwise
+    add as a documented risk in the plan.
+  - For **low** findings: note and move on.
+
+#### 5c. Check for Stuck State
+
+If after addressing findings you are **unsure how to proceed** — for example,
+the adversarial reviewer raises a concern that conflicts with a core
+requirement, or two mitigations are mutually exclusive — **stop and ask the
+user** for guidance. Present the specific dilemma and the options you see.
+
+#### 5d. Repeat
+
+Go back to step 5a with the revised plan. Use a fresh subagent each time (no
+memory of previous passes).
+
+**Bound:** If the loop has run **3 times** without reaching LGTM, present the
+current plan to the user with all remaining unresolved findings and ask how to
+proceed.
+
+### 6. Present
+
+Present the final plan to the user for approval. Clearly attribute which ideas
+came from which perspective where relevant. Note any risks that survived the
+adversarial review as known trade-offs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+## 2026-04-02 - Version 0.3.1
+CownCapsule serialization support for nested cowns.
+
+**Bug Fixes**
+
+- Removed the ownership check in `_cown_shared` that prevented a
+  `CownCapsule` from being serialized to XIData when it was the value
+  of another `Cown`. The check was unnecessary — `_cown_shared` only
+  stores a pointer and ownership is enforced at acquire time.
+
+**Improvements**
+
+- Added `CownCapsule.__reduce__` with `COWN_INCREF` pinning so that a
+  `CownCapsule` embedded in a container (dict, list, etc.) can survive
+  the pickle round-trip used by `object_to_xidata`. A module-level
+  reconstructor (`_cown_capsule_from_pointer`) inherits the pin without
+  a redundant `COWN_INCREF`, and validates the process ID on unpickle to
+  guard against cross-process misuse.
+
 ## 2026-04-01 - Version 0.3.0
 Spin-then-park receive; free-threaded Python compatibility.
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,6 +5,6 @@ authors:
   given-names: "Matthew Alastair"
   orcid: "https://orcid.org/0000-0002-1019-8036"
 title: "bocpy"
-version: 0.3.0
-date-released: 2026-04-01
+version: 0.3.1
+date-released: 2026-04-02
 url: "https://github.com/microsoft/bocpy"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bocpy"
-version = "0.3.0"
+version = "0.3.1"
 authors = [
     {name = "bocpy Team", email="bocpy@microsoft.com"}
 ]

--- a/sphinx/source/conf.py
+++ b/sphinx/source/conf.py
@@ -14,7 +14,7 @@ import textwrap
 project = 'bocpy'
 copyright = '2026, Microsoft'
 author = 'Microsoft'
-release = '0.3.0'
+release = '0.3.1'
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/src/bocpy/_core.c
+++ b/src/bocpy/_core.c
@@ -7,6 +7,7 @@
 
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
+#include <process.h>
 #include <windows.h>
 typedef volatile int_least64_t atomic_int_least64_t;
 typedef volatile intptr_t atomic_intptr_t;
@@ -139,6 +140,7 @@ atomic_int_least64_t BOC_COWN_COUNT = 0;
 #define boc_yield() SwitchToThread()
 #else
 #include <sched.h>
+#include <unistd.h>
 #define boc_yield() sched_yield()
 #endif
 
@@ -1564,6 +1566,75 @@ static PyObject *CownCapsule_get_impl(PyObject *op, void *Py_UNUSED(dummy)) {
   return Py_NewRef(op);
 }
 
+/// @brief Pickle support for CownCapsule
+/// @details Pins the inner BOCCown via COWN_INCREF so it stays alive between
+/// pickle and unpickle. The reconstructor inherits this pin (no extra INCREF).
+/// @param op The CownCapsule object
+/// @param Py_UNUSED (ignored)
+/// @return A tuple (reconstructor, (pointer, pid)) for pickle, or NULL on error
+static PyObject *CownCapsule_reduce(PyObject *op, PyObject *Py_UNUSED(dummy)) {
+  CownCapsuleObject *self = (CownCapsuleObject *)op;
+  BOCCown *cown = self->cown;
+
+  // pin the cown alive through the pickle/unpickle cycle
+  COWN_INCREF(cown);
+
+  PyObject *ptr = PyLong_FromVoidPtr(cown);
+  if (ptr == NULL) {
+    COWN_DECREF(cown);
+    return NULL;
+  }
+
+#ifdef _WIN32
+  long pid = (long)_getpid();
+#else
+  long pid = (long)getpid();
+#endif
+  PyObject *pid_obj = PyLong_FromLong(pid);
+  if (pid_obj == NULL) {
+    Py_DECREF(ptr);
+    COWN_DECREF(cown);
+    return NULL;
+  }
+
+  PyObject *module = PyImport_ImportModule("bocpy._core");
+  if (module == NULL) {
+    Py_DECREF(pid_obj);
+    Py_DECREF(ptr);
+    COWN_DECREF(cown);
+    return NULL;
+  }
+
+  PyObject *reconstructor =
+      PyObject_GetAttrString(module, "_cown_capsule_from_pointer");
+  Py_DECREF(module);
+  if (reconstructor == NULL) {
+    Py_DECREF(pid_obj);
+    Py_DECREF(ptr);
+    COWN_DECREF(cown);
+    return NULL;
+  }
+
+  PyObject *args = PyTuple_Pack(2, ptr, pid_obj);
+  Py_DECREF(ptr);
+  Py_DECREF(pid_obj);
+  if (args == NULL) {
+    Py_DECREF(reconstructor);
+    COWN_DECREF(cown);
+    return NULL;
+  }
+
+  PyObject *result = PyTuple_Pack(2, reconstructor, args);
+  Py_DECREF(reconstructor);
+  Py_DECREF(args);
+  if (result == NULL) {
+    COWN_DECREF(cown);
+    return NULL;
+  }
+
+  return result;
+}
+
 static PyMethodDef CownCapsule_methods[] = {
     {"get", CownCapsule_get, METH_NOARGS, NULL},
     {"set", CownCapsule_set, METH_VARARGS, NULL},
@@ -1571,6 +1642,7 @@ static PyMethodDef CownCapsule_methods[] = {
     {"acquire", CownCapsule_acquire, METH_NOARGS, NULL},
     {"release", CownCapsule_release, METH_NOARGS, NULL},
     {"disown", CownCapsule_disown, METH_NOARGS, NULL},
+    {"__reduce__", CownCapsule_reduce, METH_NOARGS, NULL},
     {NULL} /* Sentinel */
 };
 
@@ -1751,11 +1823,6 @@ static int _cown_shared(
 
   CownCapsuleObject *capsule = (CownCapsuleObject *)obj;
   BOCCown *cown = capsule->cown;
-
-  if (atomic_load(&cown->owner) != NO_OWNER) {
-    PyErr_SetString(PyExc_RuntimeError, "cown must be released before sending");
-    return -1;
-  }
 
   PRINTDBG("_cown_shared(%p)\n", cown);
 
@@ -3635,6 +3702,56 @@ static PyObject *_core_set_tags(PyObject *module, PyObject *args) {
   Py_RETURN_NONE;
 }
 
+/// @brief Reconstructs a CownCapsule from a pickled pointer
+/// @details Used by CownCapsule.__reduce__ to unpickle. Inherits the
+/// COWN_INCREF pin from __reduce__ (no additional INCREF). Must not use
+/// cown_capsule_wrap which would double-INCREF.
+/// @param module The _core module (unused)
+/// @param args Tuple of (pointer_as_int, process_id)
+/// @return A new CownCapsule, or NULL on error
+static PyObject *_cown_capsule_from_pointer(PyObject *module, PyObject *args) {
+  PyObject *ptr_obj, *pid_obj;
+  if (!PyArg_ParseTuple(args, "OO", &ptr_obj, &pid_obj)) {
+    return NULL;
+  }
+
+  long pickled_pid = PyLong_AsLong(pid_obj);
+  if (pickled_pid == -1 && PyErr_Occurred()) {
+    return NULL;
+  }
+
+#ifdef _WIN32
+  long current_pid = (long)_getpid();
+#else
+  long current_pid = (long)getpid();
+#endif
+  if (pickled_pid != current_pid) {
+    PyErr_SetString(PyExc_RuntimeError,
+                    "CownCapsule cannot be unpickled in a different process");
+    return NULL;
+  }
+
+  BOCCown *cown = (BOCCown *)PyLong_AsVoidPtr(ptr_obj);
+  if (cown == NULL) {
+    if (!PyErr_Occurred()) {
+      PyErr_SetString(PyExc_ValueError, "Invalid cown pointer");
+    }
+    return NULL;
+  }
+
+  // manually allocate without cown_capsule_wrap to avoid double INCREF;
+  // inherits the pin from __reduce__
+  PyTypeObject *type = BOC_STATE->cown_capsule_type;
+  CownCapsuleObject *capsule = (CownCapsuleObject *)type->tp_alloc(type, 0);
+  if (capsule == NULL) {
+    COWN_DECREF(cown);
+    return NULL;
+  }
+
+  capsule->cown = cown;
+  return (PyObject *)capsule;
+}
+
 static PyMethodDef _core_module_methods[] = {
     {"send", _core_send, METH_VARARGS, NULL},
     {"receive", (PyCFunction)(void (*)(void))_core_receive,
@@ -3650,6 +3767,8 @@ static PyMethodDef _core_module_methods[] = {
     {"recycle", _core_recycle, METH_NOARGS, NULL},
     {"cowns", _core_cowns, METH_NOARGS, NULL},
     {"set_tags", _core_set_tags, METH_VARARGS, NULL},
+    {"_cown_capsule_from_pointer", _cown_capsule_from_pointer, METH_VARARGS,
+     NULL},
     {NULL} /* Sentinel */
 };
 

--- a/test/test_boc.py
+++ b/test/test_boc.py
@@ -466,3 +466,55 @@ class TestBOC:
             send("assert", (r.value, 42))
 
         self.receive_asserts()
+
+    def test_cown_of_cown_direct(self):
+        """CownCapsule as direct child of a Cown survives release/acquire."""
+        inner = Cown(42)
+        outer = Cown(inner)
+
+        @when(outer)
+        def read_outer(o):
+            send("assert", (type(o.value).__name__, "CownCapsule"))
+
+        self.receive_asserts()
+
+    def test_cown_of_cown_access_inner(self):
+        """Inner cown's value is accessible after outer round-trip."""
+        inner = Cown(99)
+        outer = Cown(inner)
+
+        @when(outer, inner)
+        def check_both(o, i):
+            send("assert", (i.value, 99))
+
+        self.receive_asserts()
+
+    def test_cown_of_cown_in_container(self):
+        """CownCapsule nested in a dict survives pickle round-trip."""
+        inner = Cown(7)
+        outer = Cown({"key": inner})
+
+        @when(outer)
+        def check_container(o):
+            send("assert", (type(o.value["key"]).__name__, "CownCapsule"))
+
+        self.receive_asserts()
+
+    def test_cown_of_cown_schedule_inner(self):
+        """Extract inner cown from outer and schedule a behavior on it."""
+        inner = Cown(10)
+        outer = Cown(inner)
+
+        @when(outer)
+        def extract(o):
+            return o.value
+
+        @when(extract)
+        def schedule_on_inner(r):
+            inner_cown = Cown(r.value)
+
+            @when(inner_cown)
+            def read_inner(i):
+                send("assert", (i.value, 10))
+
+        self.receive_asserts()


### PR DESCRIPTION
**Bug Fixes**

- Removed the ownership check in `_cown_shared` that prevented a `CownCapsule` from being serialized to XIData when it was the value of another `Cown`. The check was unnecessary — `_cown_shared` only stores a pointer and ownership is enforced at acquire time.

**Improvements**

- Added `CownCapsule.__reduce__` with `COWN_INCREF` pinning so that a `CownCapsule` embedded in a container (dict, list, etc.) can survive the pickle round-trip used by `object_to_xidata`. A module-level reconstructor (`_cown_capsule_from_pointer`) inherits the pin without a redundant `COWN_INCREF`, and validates the process ID on unpickle to guard against cross-process misuse.
 
Fixes #7  